### PR TITLE
Rewrite current version defined in package.json using semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi.js",
-  "version": "0.2",
+  "version": "0.2.0",
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-contrib-cssmin": "^1.0.2",


### PR DESCRIPTION
Hi!

I just cloned your repo and I wasn't able to install the dependencies through npm install:

![version-error](https://cloud.githubusercontent.com/assets/1609683/24472599/2c5e3d72-14be-11e7-9cb5-7956371fff4f.png)

I realised your current master version is not compatible with npm's versioning system. Seems that a valid version is required even to pull the dependencies!

[https://docs.npmjs.com/getting-started/semantic-versioning](https://docs.npmjs.com/getting-started/semantic-versioning)

I just set the missing patch/minor release number to 0 and now works fine :)
