### PR TITLE
Avoid XSS when rendering choices

### DIFF
--- a/src/multi.js
+++ b/src/multi.js
@@ -110,7 +110,7 @@ var multi = (function() {
       var row = document.createElement("a");
       row.tabIndex = 0;
       row.className = "item";
-      row.innerHTML = label;
+      row.innerText = label;
       row.setAttribute("role", "button");
       row.setAttribute("data-value", value);
       row.setAttribute("multi-index", i);


### PR DESCRIPTION
Using innerHTML on select value is unsafe as it can contain HTML markup.

This has been reported against Weblate in our HackerOne program, I could not find how to report security issues, so I've directly created PR....